### PR TITLE
fix: remove simulated error to test failure and merge success message

### DIFF
--- a/.github/workflows/merge-upstream.yml
+++ b/.github/workflows/merge-upstream.yml
@@ -28,11 +28,7 @@ jobs:
         run: |
           git remote add $UPSTREAM_REMOTE $UPSTREAM_REPO_URL
 
-          exit 1
-
           ./merge-upstream.sh
-
-          echo "::notice:: Merge successful"
         working-directory: ./newrelic/scripts
         env:
           UPSTREAM_REPO_URL: ${{ vars.MERGE_UPSTREAM_REPO_URL }}


### PR DESCRIPTION
# Changes

* Remove the `exit 1` added to test failure handling in the `merge-upstream.yml` action
* Remove the merge successful message from `merge-upstream.yml` since it may cause confusion if no merge was needed
